### PR TITLE
Fix issue regarding empty tags & and code refactoring

### DIFF
--- a/src/main/java/io/github/easybill/Exceptions/InvalidXmlException.java
+++ b/src/main/java/io/github/easybill/Exceptions/InvalidXmlException.java
@@ -5,4 +5,8 @@ public class InvalidXmlException extends ValidatorException {
     public InvalidXmlException() {
         super();
     }
+
+    public InvalidXmlException(Throwable cause) {
+        super("the xml is invalid", cause);
+    }
 }

--- a/src/main/java/io/github/easybill/Exceptions/XmlSanitizationException.java
+++ b/src/main/java/io/github/easybill/Exceptions/XmlSanitizationException.java
@@ -1,0 +1,8 @@
+package io.github.easybill.Exceptions;
+
+public class XmlSanitizationException extends ValidatorException {
+
+    public XmlSanitizationException(Throwable cause) {
+        super("could not sanitize the xml accordingly", cause);
+    }
+}

--- a/src/main/java/io/github/easybill/Services/ValidationService.java
+++ b/src/main/java/io/github/easybill/Services/ValidationService.java
@@ -70,7 +70,7 @@ public final class ValidationService implements IValidationService {
             throw new InvalidXmlException();
         }
 
-        xml = XMLSanitizer.sanitize(xml);
+        xml = XMLSanitizer.sanitize(xml, charset);
 
         var xmlSyntaxType = XMLSyntaxGuesser
             .tryGuessSyntax(xml)

--- a/src/main/java/io/github/easybill/Services/ValidationService.java
+++ b/src/main/java/io/github/easybill/Services/ValidationService.java
@@ -19,7 +19,7 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.regex.Pattern;
+import net.sf.saxon.type.ValidationException;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.mozilla.universalchardet.UniversalDetector;
 
@@ -66,13 +66,14 @@ public final class ValidationService implements IValidationService {
 
         var xml = new String(bytesFromSteam, charset);
 
-        if (isXmlInvalid(xml)) {
+        if (xml.isBlank()) {
             throw new InvalidXmlException();
         }
 
-        xml = removeBOM(xml);
+        xml = XMLSanitizer.sanitize(xml);
 
-        var xmlSyntaxType = determineXmlSyntax(xml)
+        var xmlSyntaxType = XMLSyntaxGuesser
+            .tryGuessSyntax(xml)
             .orElseThrow(InvalidXmlException::new);
 
         var report = innerValidateSchematron(
@@ -144,56 +145,6 @@ public final class ValidationService implements IValidationService {
         throw new InvalidXmlException();
     }
 
-    private boolean isXmlInvalid(@NonNull String xml) {
-        return xml.isBlank() || (!checkIfUblXml(xml) && !checkIfCiiXml(xml));
-    }
-
-    private Optional<XMLSyntaxType> determineXmlSyntax(@NonNull String xml) {
-        if (checkIfCiiXml(xml)) {
-            return Optional.of(XMLSyntaxType.CII);
-        }
-
-        if (checkIfUblXml(xml)) {
-            return Optional.of(XMLSyntaxType.UBL);
-        }
-
-        return Optional.empty();
-    }
-
-    private boolean checkIfCiiXml(@NonNull CharSequence payload) {
-        return Pattern
-            .compile("[<:](CrossIndustryInvoice)")
-            .matcher(payload)
-            .find();
-    }
-
-    private boolean checkIfUblXml(@NonNull CharSequence payload) {
-        return Pattern
-            .compile("[<:](Invoice|CreditNote)")
-            .matcher(payload)
-            .find();
-    }
-
-    private @NonNull String removeBOM(@NonNull String $payload) {
-        String UTF8_BOM = "\uFEFF";
-        String UTF16LE_BOM = "\uFFFE";
-        String UTF16BE_BOM = "\uFEFF";
-
-        if ($payload.isEmpty()) {
-            return $payload;
-        }
-
-        if (
-            $payload.startsWith(UTF8_BOM) ||
-            $payload.startsWith(UTF16LE_BOM) ||
-            $payload.startsWith(UTF16BE_BOM)
-        ) {
-            return $payload.substring(1);
-        }
-
-        return $payload;
-    }
-
     private Optional<SchematronOutputType> innerValidateSchematron(
         @NonNull XMLSyntaxType xmlSyntaxType,
         byte[] bytes
@@ -213,6 +164,8 @@ public final class ValidationService implements IValidationService {
             };
         } catch (IllegalArgumentException exception) {
             throw new ParsingException(exception);
+        } catch (ValidationException exception) {
+            throw new InvalidXmlException(exception);
         }
     }
 }

--- a/src/main/java/io/github/easybill/Services/XMLSanitizer.java
+++ b/src/main/java/io/github/easybill/Services/XMLSanitizer.java
@@ -24,10 +24,24 @@ public final class XMLSanitizer {
     public static @NonNull String sanitize(@NonNull String xml)
         throws XmlSanitizationException {
         try {
-            return removeEmptyTags(removeBOM(xml));
+            return removeEmptyTags(
+                removeInvalidCharsFromProlog(removeBOM(xml))
+            );
         } catch (Exception exception) {
             throw new XmlSanitizationException(exception);
         }
+    }
+
+    private static @NonNull String removeInvalidCharsFromProlog(
+        @NonNull String payload
+    ) {
+        var indexOfXmlIntro = payload.indexOf("<?xml version");
+
+        if (indexOfXmlIntro == 0) {
+            return payload;
+        }
+
+        return payload.substring(indexOfXmlIntro);
     }
 
     private static @NonNull String removeBOM(@NonNull String xml) {

--- a/src/main/java/io/github/easybill/Services/XMLSanitizer.java
+++ b/src/main/java/io/github/easybill/Services/XMLSanitizer.java
@@ -1,0 +1,115 @@
+package io.github.easybill.Services;
+
+import io.github.easybill.Exceptions.XmlSanitizationException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.w3c.dom.*;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public final class XMLSanitizer {
+
+    public static @NonNull String sanitize(@NonNull String xml)
+        throws XmlSanitizationException {
+        try {
+            return removeEmptyTags(removeBOM(xml));
+        } catch (Exception exception) {
+            throw new XmlSanitizationException(exception);
+        }
+    }
+
+    private static @NonNull String removeBOM(@NonNull String xml) {
+        String UTF8_BOM = "\uFEFF";
+        String UTF16LE_BOM = "\uFFFE";
+        String UTF16BE_BOM = "\uFEFF";
+
+        if (xml.isEmpty()) {
+            return xml;
+        }
+
+        if (
+            xml.startsWith(UTF8_BOM) ||
+            xml.startsWith(UTF16LE_BOM) ||
+            xml.startsWith(UTF16BE_BOM)
+        ) {
+            return xml.substring(1);
+        }
+
+        return xml;
+    }
+
+    private static @NonNull String removeEmptyTags(@NonNull String xml)
+        throws ParserConfigurationException, IOException, SAXException, TransformerException {
+        var builderFactory = DocumentBuilderFactory.newInstance();
+        builderFactory.setNamespaceAware(true);
+        builderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        DocumentBuilder db = builderFactory.newDocumentBuilder();
+
+        Document document = db.parse(new InputSource(new StringReader(xml)));
+
+        removeEmptyElements(document.getDocumentElement());
+
+        TransformerFactory transformerFactory =
+            TransformerFactory.newInstance();
+
+        Transformer transformer = transformerFactory.newTransformer();
+
+        StringWriter writer = new StringWriter();
+
+        transformer.transform(
+            new DOMSource(document),
+            new StreamResult(writer)
+        );
+
+        return writer.toString();
+    }
+
+    private static void removeEmptyElements(Element element) {
+        NodeList children = element.getChildNodes();
+
+        for (int i = children.getLength() - 1; i >= 0; i--) {
+            Node child = children.item(i);
+
+            if (child == null) {
+                continue;
+            }
+
+            if (child.getNodeType() == Node.ELEMENT_NODE) {
+                removeEmptyElements((Element) child);
+            }
+
+            if (
+                child.getNodeType() == Node.ELEMENT_NODE &&
+                isEmptyElement((Element) child)
+            ) {
+                element.removeChild(child);
+            }
+        }
+    }
+
+    private static boolean isEmptyElement(Element element) {
+        return (
+            element.getChildNodes().getLength() == 0 ||
+            (
+                element.getChildNodes().getLength() == 1 &&
+                element.getFirstChild() != null &&
+                element.getFirstChild().getNodeType() == Node.TEXT_NODE &&
+                element.getFirstChild().getTextContent() != null &&
+                element.getFirstChild().getTextContent().trim().isEmpty()
+            )
+        );
+    }
+}

--- a/src/main/java/io/github/easybill/Services/XMLSyntaxGuesser.java
+++ b/src/main/java/io/github/easybill/Services/XMLSyntaxGuesser.java
@@ -1,0 +1,35 @@
+package io.github.easybill.Services;
+
+import io.github.easybill.Enums.XMLSyntaxType;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public final class XMLSyntaxGuesser {
+
+    public static Optional<XMLSyntaxType> tryGuessSyntax(@NonNull String xml) {
+        if (checkIfCiiXml(xml)) {
+            return Optional.of(XMLSyntaxType.CII);
+        }
+
+        if (checkIfUblXml(xml)) {
+            return Optional.of(XMLSyntaxType.UBL);
+        }
+
+        return Optional.empty();
+    }
+
+    private static boolean checkIfCiiXml(@NonNull CharSequence payload) {
+        return Pattern
+            .compile("[<:](CrossIndustryInvoice)")
+            .matcher(payload)
+            .find();
+    }
+
+    private static boolean checkIfUblXml(@NonNull CharSequence payload) {
+        return Pattern
+            .compile("[<:](Invoice|CreditNote)")
+            .matcher(payload)
+            .find();
+    }
+}

--- a/src/test/java/io/github/easybill/ValidationControllerTest.java
+++ b/src/test/java/io/github/easybill/ValidationControllerTest.java
@@ -68,6 +68,26 @@ class ValidationControllerTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = { "CII/CII_empty_tags.xml" })
+    void testDocumentWithEmptyTags(@NonNull String fixtureFileName)
+        throws IOException {
+        given()
+            .body(loadFixtureFileAsStream(fixtureFileName))
+            .contentType(ContentType.XML)
+            .when()
+            .post("/validation")
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("is_valid", equalTo(false))
+            .body(
+                "meta.validation_profile",
+                equalTo(XMLSyntaxType.CII.toString())
+            )
+            .body("errors", not(empty()));
+    }
+
+    @ParameterizedTest
     @ValueSource(
         strings = {
             "UBL/Allowance-example.xml",

--- a/src/test/java/io/github/easybill/ValidationControllerTest.java
+++ b/src/test/java/io/github/easybill/ValidationControllerTest.java
@@ -64,7 +64,7 @@ class ValidationControllerTest {
             .when()
             .post("/validation")
             .then()
-            .statusCode(422);
+            .statusCode(200);
     }
 
     @ParameterizedTest
@@ -167,7 +167,6 @@ class ValidationControllerTest {
             "CII/CII_ZUGFeRD_23_XRECHNUNG_Einfach.xml",
             "CII/CII_ZUGFeRD_23_XRECHNUNG_Elektron.xml",
             "CII/CII_ZUGFeRD_23_XRECHNUNG_Reisekostenabrechnung.xml",
-            "CII/XRechnung-O.xml",
             "CII/CII_ZUGFeRD_23_EXTENDED_Rechnungskorrektur.xml",
         }
     )
@@ -208,7 +207,8 @@ class ValidationControllerTest {
             Arguments.of(
                 "CII/CII_ZUGFeRD_23_EXTENDED_Projektabschlussrechnung.xml"
             ),
-            Arguments.of("CII/CII_ZUGFeRD_23_EXTENDED_Warenrechnung.xml")
+            Arguments.of("CII/CII_ZUGFeRD_23_EXTENDED_Warenrechnung.xml"),
+            Arguments.of("CII/XRechnung-O.xml")
         );
     }
 

--- a/src/test/resources/CII/CII_empty_tags.xml
+++ b/src/test/resources/CII/CII_empty_tags.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+                          xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                          xmlns="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100">
+
+    <rsm:ExchangedDocumentContext>
+        <ram:TestIndicator>
+            <udt:Indicator>false</udt:Indicator>
+        </ram:TestIndicator>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
+    <rsm:ExchangedDocument>
+        <ram:ID>914077854</ram:ID>
+        <ram:Name>GUTSCHRIFT</ram:Name>
+        <ram:TypeCode>389</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20241223</udt:DateTimeString>
+        </ram:IssueDateTime>
+        <ram:IncludedNote>
+            <ram:Content>Bezüglich der späteren Entgeltminderung verweisen wir auf die Rabattkonditionen in der
+                jeweiligen aktuellen Fassung
+            </ram:Content>
+            <ram:SubjectCode>REG</ram:SubjectCode>
+        </ram:IncludedNote>
+        <ram:IncludedNote>
+            <ram:Content>sofort zahlbar ohne Abzug</ram:Content>
+            <ram:SubjectCode>REG</ram:SubjectCode>
+        </ram:IncludedNote>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>000100</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:SellerAssignedID>00000079157</ram:SellerAssignedID>
+                <ram:Name>Abrechnung Example Direct</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:BuyerOrderReferencedDocument>
+                    <ram:IssuerAssignedID>Vergüt. Example Direct - 23.12.2024</ram:IssuerAssignedID>
+                </ram:BuyerOrderReferencedDocument>
+                <ram:AdditionalReferencedDocument>
+                    <ram:IssuerAssignedID>0803045309</ram:IssuerAssignedID>
+                    <ram:TypeCode>130</ram:TypeCode>
+                    <ram:ReferenceTypeCode>VN</ram:ReferenceTypeCode>
+                </ram:AdditionalReferencedDocument>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount>57.6700</ram:ChargeAmount>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>57.6700</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="C62">1.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent/>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>57.67</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:BuyerReference>Vergüt. Example Direct - 23.12.2024</ram:BuyerReference>
+            <ram:SellerTradeParty>
+                <ram:GlobalID schemeID="0088">4330731000007</ram:GlobalID>
+                <ram:Name>Example Seller</ram:Name>
+                <ram:DefinedTradeContact>
+                    <ram:PersonName>Example Debitorenbuchhaltung</ram:PersonName>
+                    <ram:DepartmentName>Example Debitorenbuchhaltung</ram:DepartmentName>
+                    <ram:TelephoneUniversalCommunication>
+                        <ram:CompleteNumber>06071 2040</ram:CompleteNumber>
+                    </ram:TelephoneUniversalCommunication>
+                    <ram:EmailURIUniversalCommunication>
+                        <ram:URIID>Vertriebszentrale@Example.de</ram:URIID>
+                    </ram:EmailURIUniversalCommunication>
+                </ram:DefinedTradeContact>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>64807</ram:PostcodeCode>
+                    <ram:LineOne>Robert-Bosch-Str. 13</ram:LineOne>
+                    <ram:CityName>Dieburg</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE111746670</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:ID>0000000000</ram:ID>
+                <ram:Name>Example </ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>25813</ram:PostcodeCode>
+                    <ram:LineOne>Examplestreet</ram:LineOne>
+                    <ram:CityName>Husum</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:BuyerTradeParty>
+            <ram:BuyerOrderReferencedDocument>
+                <ram:IssuerAssignedID>Vergüt. Example Direct - 23.12.2024</ram:IssuerAssignedID>
+            </ram:BuyerOrderReferencedDocument>
+            <ram:AdditionalReferencedDocument>
+                <ram:IssuerAssignedID>0803045309</ram:IssuerAssignedID>
+                <ram:TypeCode>130</ram:TypeCode>
+            </ram:AdditionalReferencedDocument>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery>
+            <ram:ShipToTradeParty>
+                <ram:ID>0000000000</ram:ID>
+                <ram:Name>Example GmbH</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>25813</ram:PostcodeCode>
+                    <ram:LineOne>Examplestreet</ram:LineOne>
+                    <ram:CityName>Example City</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:ShipToTradeParty>
+            <ram:ActualDeliverySupplyChainEvent>
+                <ram:OccurrenceDateTime>
+                    <udt:DateTimeString format="102">20241223</udt:DateTimeString>
+                </ram:OccurrenceDateTime>
+            </ram:ActualDeliverySupplyChainEvent>
+            <ram:DeliveryNoteReferencedDocument/>
+        </ram:ApplicableHeaderTradeDelivery>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:InvoiceeTradeParty>
+                <ram:ID>0000000000</ram:ID>
+                <ram:Name>Example GmbH</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>25813</ram:PostcodeCode>
+                    <ram:LineOne>Examplestreet</ram:LineOne>
+                    <ram:CityName>Example City</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:InvoiceeTradeParty>
+            <ram:SpecifiedTradeSettlementPaymentMeans>
+                <ram:TypeCode>42</ram:TypeCode>
+                <ram:PayeePartyCreditorFinancialAccount>
+                    <ram:IBANID>DE62508526510033203159</ram:IBANID>
+                </ram:PayeePartyCreditorFinancialAccount>
+                <ram:PayeeSpecifiedCreditorFinancialInstitution>
+                    <ram:BICID>HELADEF1DIE</ram:BICID>
+                </ram:PayeeSpecifiedCreditorFinancialInstitution>
+            </ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:SpecifiedTradeSettlementPaymentMeans>
+                <ram:TypeCode>42</ram:TypeCode>
+                <ram:PayeePartyCreditorFinancialAccount>
+                    <ram:IBANID>DE11111111111111111111111111</ram:IBANID>
+                </ram:PayeePartyCreditorFinancialAccount>
+                <ram:PayeeSpecifiedCreditorFinancialInstitution>
+                    <ram:BICID>COBADEFFXXX</ram:BICID>
+                </ram:PayeeSpecifiedCreditorFinancialInstitution>
+            </ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount>10.96</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount>57.67</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeAllowanceCharge>
+                <ram:ChargeIndicator>
+                    <udt:Indicator>false</udt:Indicator>
+                </ram:ChargeIndicator>
+                <ram:ActualAmount>0.00</ram:ActualAmount>
+                <ram:Reason>Rabatt</ram:Reason>
+                <ram:CategoryTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+                </ram:CategoryTradeTax>
+            </ram:SpecifiedTradeAllowanceCharge>
+            <ram:SpecifiedTradePaymentTerms>
+                <ram:Description>Bis zum 23.12.2024 ohne Abzug</ram:Description>
+            </ram:SpecifiedTradePaymentTerms>
+            <ram:SpecifiedTradePaymentTerms>
+                <ram:Description>sofort zahlbar ohne Abzug</ram:Description>
+                <ram:ApplicableTradePaymentDiscountTerms>
+                    <ram:BasisDateTime>
+                        <udt:DateTimeString format="102">20241223</udt:DateTimeString>
+                    </ram:BasisDateTime>
+                </ram:ApplicableTradePaymentDiscountTerms>
+            </ram:SpecifiedTradePaymentTerms>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount>57.67</ram:LineTotalAmount>
+                <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
+                <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
+                <ram:TaxBasisTotalAmount>57.67</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">10.96</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount>68.63</ram:GrandTotalAmount>
+                <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+                <ram:DuePayableAmount>68.63</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
If a XML is parsed which includes empty-Tags which will be used for Schematron-Validation (like asserting it is a double) it will throw an Exception and returns a 500. Know the parsing will ignore empty tags.